### PR TITLE
Fix typo in CodeHub Pro features text

### DIFF
--- a/CodeHub.iOS/ViewControllers/Repositories/PrivateRepositoryViewController.xib
+++ b/CodeHub.iOS/ViewControllers/Repositories/PrivateRepositoryViewController.xib
@@ -37,7 +37,7 @@
                                     <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                     <nil key="highlightedColor"/>
                                 </label>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="251" verticalCompressionResistancePriority="1000" misplaced="YES" text="Private repositories are only availble with CodeHub Pro. Click the button below for more details." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="N07-18-8l1">
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="251" verticalCompressionResistancePriority="1000" misplaced="YES" text="Private repositories are only available with CodeHub Pro. Click the button below for more details." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="N07-18-8l1">
                                     <rect key="frame" x="20" y="319" width="560" height="56"/>
                                     <constraints>
                                         <constraint firstAttribute="width" constant="400" id="66F-z2-11F"/>

--- a/CodeHub.iOS/WebViews/UpgradeDetailsRazorView.cs
+++ b/CodeHub.iOS/WebViews/UpgradeDetailsRazorView.cs
@@ -183,7 +183,7 @@ WriteLiteral(" id=\"private\"");
 
 WriteLiteral(@">Private Repositories</h3>
     <p>
-        While CodeHub is free for all public projects, private repositories are only availble with CodeHub Pro.
+        While CodeHub is free for all public projects, private repositories are only available with CodeHub Pro.
         The Pro edition allows access to all your private repositories and any private repositories any of your organizations have.
         Access to your private repositories is completely unrestricted. With CodeHub Pro, anything you are able to do with your open source repositories
         you are also capable of doing with your private repositories. Even more, access to private repositories, with CodeHub Pro, is applied to

--- a/CodeHub.iOS/WebViews/UpgradeDetailsRazorView.cshtml
+++ b/CodeHub.iOS/WebViews/UpgradeDetailsRazorView.cshtml
@@ -172,7 +172,7 @@ ul.task-list > li.task-list-item {
 
     <h3 id="private">Private Repositories</h3>
     <p>
-        While CodeHub is free for all public projects, private repositories are only availble with CodeHub Pro.
+        While CodeHub is free for all public projects, private repositories are only available with CodeHub Pro.
         The Pro edition allows access to all your private repositories and any private repositories any of your organizations have.
         Access to your private repositories is completely unrestricted. With CodeHub Pro, anything you are able to do with your open source repositories
         you are also capable of doing with your private repositories. Even more, access to private repositories, with CodeHub Pro, is applied to


### PR DESCRIPTION
- Searched for instances of "availble" and replaced with "available".

To reproduce:
- Open sidebar "hamburger menu"
- Open Upgrades
- Scroll down to Private Repositories and look at the first sentence

I wasn't able to build it because I don't have an Apple Developer account at the moment. I couldn't do it with free provisioning because the app has in-app purchases. I randomly came across the typo when I was looking at 